### PR TITLE
Add Quality Control section to the ATN Specifications Page

### DIFF
--- a/_docs/atn-sat-telem-specification-v1-0.md
+++ b/_docs/atn-sat-telem-specification-v1-0.md
@@ -1817,7 +1817,8 @@ ATN DAC quality control protocols handle animal trajectory and dive profile data
 The following `ioos_qc` tests are applied: 
 * `ioos_qc.argo.speed_test`
 * `ioos_qc.qartod.location_test`
-* `ioos_qc.qartod.gross_range_test` - for temperature and salinity
+* `ioos_qc.qartod.gross_range_test`
+* `ioos_qc.axds.valid_range_test`
 
 The table below summarizes the thresholds for each test and parameter. The temperature thresholds and salinity upper bound threshold are taken from the [Argo Quality Control Manual for CTD and Trajectory Data](https://archimer.ifremer.fr/doc/00228/33951/):
 
@@ -1830,9 +1831,7 @@ The table below summarizes the thresholds for each test and parameter. The tempe
 
 TODO: Check on sal lower bound. The argo manual says 2.
 
-#### Date Tests
-
-Valid start and end deployment dates are either provided in an XML metadata file alongside the data files or manually submitted through the ATN Data Registration portal. These provided date ranges are used to truncate the data on both ends, to account for time on land before deployment and after retrieval.
+The `ioos_qc.axds.valid_range_test()` is applied by checking the ingested data against provider-supplied start and end deployment dates. Valid start and end deployment dates are either accessed from an XML metadata file alongside the data files or manually submitted through the ATN Data Registration portal. These provided date ranges are used to truncate the data on both ends, to account for time on land before deployment and after retrieval.
 
 
 #### Implementation Example

--- a/_docs/atn-sat-telem-specification-v1-0.md
+++ b/_docs/atn-sat-telem-specification-v1-0.md
@@ -1828,10 +1828,27 @@ The table below summarizes the thresholds for each test and parameter. The tempe
 | ioos_qc.argo.location_test | Latitude / Longitude | n/a | [-180, -90, 180, 90] |
 | ioos_qc.qartod.gross_range_test | Temperature | n/a | [-2.5, 40] |
 | ioos_qc.qartod.gross_range_test | Salinity | n/a | [0.0, 41.0] |
+| ioos_qc.axds.valid_range_test | Starting Time | n/a | Varies |
+| ioos_qc.axds.valid_range_test | Ending Time | n/a | Varies |
 
 TODO: Check on sal lower bound. The argo manual says 2.
 
-The `ioos_qc.axds.valid_range_test()` is applied by checking the ingested data against provider-supplied start and end deployment dates. Valid start and end deployment dates are either accessed from an XML metadata file alongside the data files or manually submitted through the ATN Data Registration portal. These provided date ranges are used to truncate the data on both ends, to account for time on land before deployment and after retrieval.
+The `ioos_qc.axds.valid_range_test()` is applied by checking the ingested data against provider-supplied start and end deployment dates, if available. Valid start and end deployment dates are either accessed from manually submitted deployment information saved in the [ATN Data Registration portal (ADR)](https://dacregistration.atn.ioos.us/) or from an XML metadata file packaged alongside the data files. When both are available, the ADR deployment dates are used as the source of truth. The provided date ranges are converted to `datetime` and used to truncate the data on both ends, to account for time on land before deployment and after retrieval.
+
+Currently, only auto-ingested Wildlife Computer tag data include start and end date metadata (epoch time) in the corresponding XML file, which might look something like this:
+
+```
+<deployment>
+    <start>
+        <date>1464789420</date>
+        <latitude>34.2178</latitude>
+        <longitude>-120.5634</longitude>
+    </start>
+    <end>
+        <date>1465776000</date>
+    </end>
+</deployment>
+```
 
 
 #### Implementation Example

--- a/_docs/atn-sat-telem-specification-v1-0.md
+++ b/_docs/atn-sat-telem-specification-v1-0.md
@@ -1832,7 +1832,7 @@ The table below summarizes the thresholds for each test and parameter. The tempe
 | ioos_qc.axds.valid_range_test | Starting Time | n/a | Varies |
 | ioos_qc.axds.valid_range_test | Ending Time | n/a | Varies |
 
-The Argo Quality Control Manual suggests a gross range lower bound of 2 psu for salinity, but here we set it to 0 psu.
+Note: While the Argo Quality Control Manual suggests a gross range lower bound of 2 psu for salinity, modern conductivity-based salinity sensors can measure near 0 psu conditions with reasonable accuracy and without signal degradation ([Menn & Nair 2022](https://www.frontiersin.org/journals/marine-science/articles/10.3389/fmars.2022.1031824/full)). NOAA's [Manual for Real-Time Quality Control](https://repository.library.noaa.gov/view/noaa/23701) defines the Gross Range Test to flag measurements outside of a sensor's operational limits. Therefore, the lower bound we use here is 0 psu.
 
 #### Temporal Valid Range Test
 

--- a/_docs/atn-sat-telem-specification-v1-0.md
+++ b/_docs/atn-sat-telem-specification-v1-0.md
@@ -1819,7 +1819,7 @@ The following `ioos_qc` tests are applied:
 * `ioos_qc.qartod.location_test`
 * `ioos_qc.qartod.gross_range_test` - for temperature and salinity
 
-The table below summarizes the default thresholds for each test and parameter. The temperature thresholds and salinity upper bound threshold are taken from the [Argo Quality Control Manual for CTD and Trajectory Data](https://archimer.ifremer.fr/doc/00228/33951/):
+The table below summarizes the thresholds for each test and parameter. The temperature thresholds and salinity upper bound threshold are taken from the [Argo Quality Control Manual for CTD and Trajectory Data](https://archimer.ifremer.fr/doc/00228/33951/):
 
 | Test | Parameter | Suspect | Fail |
 |----------|----------|----------|
@@ -1828,19 +1828,11 @@ The table below summarizes the default thresholds for each test and parameter. T
 | ioos_qc.qartod.gross_range_test | Temperature | n/a | [-2.5, 40] |
 | ioos_qc.qartod.gross_range_test | Salinity | n/a | [0.0, 41.0] |
 
-TODO: Check on sal lower bound. The argo manual says 2, but this threshold is for all our platforms.
+TODO: Check on sal lower bound. The argo manual says 2.
 
 #### Date Tests
 
 Valid start and end deployment dates are either provided in an XML metadata file alongside the data files or manually submitted through the ATN Data Registration portal. These provided date ranges are used to truncate the data on both ends, to account for time on land before deployment and after retrieval.
-
-#### Trajectory & Profile Data
-
-TODO: finish this section
-
-In addition to the above tests for trajectory data, we also check that z is [0, 0] since it is horizontal, surface trajectory information.
-
-For profiles, we evaluate temperature, salinity, sea water electrical conductivity, depth.
 
 
 #### Implementation Example

--- a/_docs/atn-sat-telem-specification-v1-0.md
+++ b/_docs/atn-sat-telem-specification-v1-0.md
@@ -1807,3 +1807,75 @@ Attributes:
     actual_min:     0.0
     actual_max:     0.0
 ```
+
+### Quality Control Protocols
+
+ATN DAC quality control protocols handle animal trajectory and dive profile data and uses the `ioos_qc` Python package to implement multiple QARTOD tests and an aggregate rollup flag.
+
+#### Speed, Location, Range Tests
+
+The following `ioos_qc` tests are applied: 
+* `ioos_qc.argo.speed_test`
+* `ioos_qc.qartod.location_test`
+* `ioos_qc.qartod.gross_range_test` - for temperature and salinity
+
+With these default thresholds. The temperature and salinity thresholds are taken from the ARGOS QC Manual:
+
+| Test | Parameter | Suspect | Fail |
+|----------|----------|----------|
+| ioos_qc.argo.speed_test | Speed | 8.0 m/s | 10.0 m/s |
+| ioos_qc.argo.location_test | Latitude / Longitude | n/a | [-180, -90, 180, 90] |
+| ioos_qc.qartod.gross_range_test | Temperature | n/a | [-2.5, 40] |
+| ioos_qc.qartod.gross_range_test | Salinity | n/a | [0.0, 41.0] |
+
+#### Date Tests
+
+Valid start and end deployment dates are either provided in an XML metadata file alongside the data files or manually submitted through the ATN Data Registration portal. These provided date ranges are used to truncate the data on both ends, to account for time on land before deployment and after retrieval.
+
+#### Trajectory & Profile Data
+
+# TODO: finish this section
+
+In addition to the above tests for trajectory data, we also check that z is [0, 0] since it is horizontal, surface trajectory information.
+
+For profiles, we evaluate temperature, salinity, sea water electrical conductivity, depth.
+
+
+#### Implementation Example
+
+# TODO: Add examples of `df` and `Config`
+# TODO: Add example of what `results_store` looks like
+# TODO: Link to an example notebook
+Snippet of `ioos_qc` implementation:
+
+```
+from ioos_qc.stores import PandasStore
+from ioos_qc.streams import Config, PandasStream
+
+def apply_qc(df: pd.DataFrame, config: Config) -> pd.DataFrame:
+    # Setup the stream
+    stream = PandasStream(df)
+
+    # Run the tests
+    results = stream.run(config)
+
+    # Store the results in another DataFrame
+    store = PandasStore(
+        results,
+        axes={
+            't': 'time',
+            'z': 'z',
+            'y': 'lat',
+            'x': 'lon'
+        }
+    )
+
+    # Compute any aggregations
+    store.compute_aggregate(name='rollup_qc')  # Appends to the results internally
+
+    # Write only the test results to the store
+    results_store = store.save(write_data=False, write_axes=False)
+
+    # Append columns from qc results back into the data
+    return pd.concat([df, results_store], axis=1)
+```

--- a/_docs/atn-sat-telem-specification-v1-0.md
+++ b/_docs/atn-sat-telem-specification-v1-0.md
@@ -1824,7 +1824,7 @@ The following `ioos_qc` tests are applied:
 The table below summarizes the thresholds for each test and parameter. The temperature thresholds and salinity upper bound threshold are taken from the [Argo Quality Control Manual for CTD and Trajectory Data](https://archimer.ifremer.fr/doc/00228/33951/):
 
 | Test | Parameter | Suspect | Fail |
-|----------|----------|----------|
+|----------|----------|----------|----------|
 | ioos_qc.argo.speed_test | Speed | If over 8.0 m/s | If over 10.0 m/s |
 | ioos_qc.argo.location_test | Latitude / Longitude | n/a | If falls outside of [-180, -90, 180, 90] |
 | ioos_qc.qartod.gross_range_test | Temperature (C) | n/a | If falls outside of [-2.5, 40] |

--- a/_docs/atn-sat-telem-specification-v1-0.md
+++ b/_docs/atn-sat-telem-specification-v1-0.md
@@ -1812,26 +1812,30 @@ Attributes:
 
 ATN DAC quality control protocols handle animal trajectory and dive profile data and uses the `ioos_qc` Python package to implement multiple QARTOD tests and an aggregate rollup flag.
 
-#### Speed, Location, Range Tests
+See this example notebook for more details.
+
+#### Speed, Location, Gross Range Tests
 
 The following `ioos_qc` tests are applied: 
-* `ioos_qc.argo.speed_test`
-* `ioos_qc.qartod.location_test`
-* `ioos_qc.qartod.gross_range_test`
-* `ioos_qc.axds.valid_range_test`
+* [`ioos_qc.argo.speed_test`](https://ioos.github.io/ioos_qc/api/ioos_qc.html#ioos_qc.argo.speed_test)
+* [`ioos_qc.qartod.location_test`](https://ioos.github.io/ioos_qc/api/ioos_qc.html#ioos_qc.qartod.location_test)
+* [`ioos_qc.qartod.gross_range_test`](https://ioos.github.io/ioos_qc/api/ioos_qc.html#ioos_qc.qartod.gross_range_test)
+* [`ioos_qc.axds.valid_range_test`](https://ioos.github.io/ioos_qc/api/ioos_qc.html#ioos_qc.axds.valid_range_test)
 
 The table below summarizes the thresholds for each test and parameter. The temperature thresholds and salinity upper bound threshold are taken from the [Argo Quality Control Manual for CTD and Trajectory Data](https://archimer.ifremer.fr/doc/00228/33951/):
 
 | Test | Parameter | Suspect | Fail |
 |----------|----------|----------|
-| ioos_qc.argo.speed_test | Speed | 8.0 m/s | 10.0 m/s |
-| ioos_qc.argo.location_test | Latitude / Longitude | n/a | [-180, -90, 180, 90] |
-| ioos_qc.qartod.gross_range_test | Temperature | n/a | [-2.5, 40] |
-| ioos_qc.qartod.gross_range_test | Salinity | n/a | [0.0, 41.0] |
+| ioos_qc.argo.speed_test | Speed | If over 8.0 m/s | If over 10.0 m/s |
+| ioos_qc.argo.location_test | Latitude / Longitude | n/a | If falls outside of [-180, -90, 180, 90] |
+| ioos_qc.qartod.gross_range_test | Temperature (C) | n/a | If falls outside of [-2.5, 40] |
+| ioos_qc.qartod.gross_range_test | Salinity (psu) | n/a | If falls outside of [0.0, 41.0] |
 | ioos_qc.axds.valid_range_test | Starting Time | n/a | Varies |
 | ioos_qc.axds.valid_range_test | Ending Time | n/a | Varies |
 
-TODO: Check on sal lower bound. The argo manual says 2.
+The Argo Quality Control Manual suggests a gross range lower bound of 2 psu for salinity, but here we set it to 0 psu.
+
+#### Temporal Valid Range Test
 
 The `ioos_qc.axds.valid_range_test()` is applied by checking the ingested data against provider-supplied start and end deployment dates, if available. Valid start and end deployment dates are either accessed from manually submitted deployment information saved in the [ATN Data Registration portal (ADR)](https://dacregistration.atn.ioos.us/) or from an XML metadata file packaged alongside the data files. When both are available, the ADR deployment dates are used as the source of truth. The provided date ranges are converted to `datetime` and used to truncate the data on both ends, to account for time on land before deployment and after retrieval.
 
@@ -1848,44 +1852,4 @@ Currently, only auto-ingested Wildlife Computer tag data include start and end d
         <date>1465776000</date>
     </end>
 </deployment>
-```
-
-
-#### Implementation Example
-
-TODO: Add examples of `df` and `Config`
-TODO: Add example of what `results_store` looks like
-TODO: Link to an example notebook
-Snippet of `ioos_qc` implementation:
-
-```
-from ioos_qc.stores import PandasStore
-from ioos_qc.streams import Config, PandasStream
-
-def apply_qc(df: pd.DataFrame, config: Config) -> pd.DataFrame:
-    # Setup the stream
-    stream = PandasStream(df)
-
-    # Run the tests
-    results = stream.run(config)
-
-    # Store the results in another DataFrame
-    store = PandasStore(
-        results,
-        axes={
-            't': 'time',
-            'z': 'z',
-            'y': 'lat',
-            'x': 'lon'
-        }
-    )
-
-    # Compute any aggregations
-    store.compute_aggregate(name='rollup_qc')  # Appends to the results internally
-
-    # Write only the test results to the store
-    results_store = store.save(write_data=False, write_axes=False)
-
-    # Append columns from qc results back into the data
-    return pd.concat([df, results_store], axis=1)
 ```

--- a/_docs/atn-sat-telem-specification-v1-0.md
+++ b/_docs/atn-sat-telem-specification-v1-0.md
@@ -1812,7 +1812,6 @@ Attributes:
 
 ATN DAC quality control protocols handle animal trajectory and dive profile data and uses the `ioos_qc` Python package to implement multiple QARTOD tests and an aggregate rollup flag.
 
-See this example notebook for more details.
 
 #### Speed, Location, Gross Range Tests
 

--- a/_docs/atn-sat-telem-specification-v1-0.md
+++ b/_docs/atn-sat-telem-specification-v1-0.md
@@ -1819,7 +1819,7 @@ The following `ioos_qc` tests are applied:
 * `ioos_qc.qartod.location_test`
 * `ioos_qc.qartod.gross_range_test` - for temperature and salinity
 
-With these default thresholds. The temperature and salinity thresholds are taken from the ARGOS QC Manual:
+The table below summarizes the default thresholds for each test and parameter. The temperature thresholds and salinity upper bound threshold are taken from the [Argo Quality Control Manual for CTD and Trajectory Data](https://archimer.ifremer.fr/doc/00228/33951/):
 
 | Test | Parameter | Suspect | Fail |
 |----------|----------|----------|
@@ -1828,13 +1828,15 @@ With these default thresholds. The temperature and salinity thresholds are taken
 | ioos_qc.qartod.gross_range_test | Temperature | n/a | [-2.5, 40] |
 | ioos_qc.qartod.gross_range_test | Salinity | n/a | [0.0, 41.0] |
 
+TODO: Check on sal lower bound. The argo manual says 2, but this threshold is for all our platforms.
+
 #### Date Tests
 
 Valid start and end deployment dates are either provided in an XML metadata file alongside the data files or manually submitted through the ATN Data Registration portal. These provided date ranges are used to truncate the data on both ends, to account for time on land before deployment and after retrieval.
 
 #### Trajectory & Profile Data
 
-# TODO: finish this section
+TODO: finish this section
 
 In addition to the above tests for trajectory data, we also check that z is [0, 0] since it is horizontal, surface trajectory information.
 
@@ -1843,9 +1845,9 @@ For profiles, we evaluate temperature, salinity, sea water electrical conductivi
 
 #### Implementation Example
 
-# TODO: Add examples of `df` and `Config`
-# TODO: Add example of what `results_store` looks like
-# TODO: Link to an example notebook
+TODO: Add examples of `df` and `Config`
+TODO: Add example of what `results_store` looks like
+TODO: Link to an example notebook
 Snippet of `ioos_qc` implementation:
 
 ```


### PR DESCRIPTION
Added the "Quality Control Protocols" section to the "ATN Satellite Telemetry Specification Version 1.0" page. This section outlines the tests applied to ATN data and the thresholds used.